### PR TITLE
In situ new model def

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,11 +9,10 @@ Authors@R:
            comment = c(ORCID = "0000-0002-4013-6530"))
            )
 Version: 3.0.0
-Description: Create short sprint (<6sec) profiles using the split times or the radar gun data.
-    Mono-exponential equation is used to estimate maximal sprinting speed (MSS), relative acceleration (TAU),
-    and other parameters such us maximal acceleration (MAC) and maximal relative power (PMAX). These parameters 
-    can be used to predict kinematic and kinetics variables and to compare individuals. The modeling method utilized
-    in this package is based on the works of 
+Description: Create short sprint acceleration-velocity (AVP) and force-velocity (FVP) profiles
+     and predict kinematic and kinetic variables using the timing-gate split times, laser or 
+     radar gun data, tether devices data, as well as the data provided by the GPS and LPS 
+     monitoring systems. The modeling method utilized in this package is based on the works of 
     Furusawa K, Hill AV, Parkinson JL (1927) <doi: 10.1098/rspb.1927.0035>, 
     Greene PR. (1986) <doi: 10.1016/0025-5564(86)90063-5>, 
     Chelly SM, Denis C. (2001) <doi: 10.1097/00005768-200102000-00024>,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # shorts 3.1.0
 
 * Fixed the error in `model_radar_gun()` example that happened on `r-release-macos-arm64` and `r-oldrel-macos-arm64` due to the perfect model fit causing "singular gradient matrix at initial parameter estimates". This is sorted by adding simple noise to the simulated data
+* Updated the DESCRIPTION file with better package description
 
 # shorts 3.0.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# shorts 3.1.0
+
+* Fixed the error in `model_radar_gun()` example that happened on `r-release-macos-arm64` and `r-oldrel-macos-arm64` due to the perfect model fit causing "singular gradient matrix at initial parameter estimates". This is sorted by adding simple noise to the simulated data
+
 # shorts 3.0.0
 
 ## Fixed Bugs and Errors

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # shorts 3.1.0
 
 * Fixed the error in `model_radar_gun()` example that happened on `r-release-macos-arm64` and `r-oldrel-macos-arm64` due to the perfect model fit causing "singular gradient matrix at initial parameter estimates". This is sorted by adding simple noise to the simulated data
+* Modified `model_in_situ()` function to now use `minpack.lm::nlsLM()` instead of `stats::lm()` function, which now estimates `MSS` and `MAC` parameters, and it is thus easier to read the code, and estimate the confidence intervals
 * Updated the DESCRIPTION file with better package description
 
 # shorts 3.0.0

--- a/R/model-radar-gun.R
+++ b/R/model-radar-gun.R
@@ -6,6 +6,10 @@
 #'
 #' # Model Radar Gun (includes Time Correction)
 #' df <- create_sprint_trace(MSS = 8, MAC = 6, time = seq(0, 6, 0.1))
+#'
+#' # Add some noise
+#' df$velocity <- df$velocity + rnorm(n = nrow(df), 0, 10^-2)
+#'
 #' m1 <- model_radar_gun(time = df$time, velocity = df$velocity)
 #' m1
 #' plot(m1)

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -8,7 +8,7 @@ bibentry(
            email = "coach.mladen.jovanovic@gmail.com")
      ),
      year = "2024",
-     note = "R package version 3.0.0",
+     note = "R package version 3.1.0",
      url = "https://CRAN.R-project.org/package=shorts",
      key = "shorts-package"
    )

--- a/man/model_functions.Rd
+++ b/man/model_functions.Rd
@@ -250,6 +250,10 @@ plot(m1)
 
 # Model Radar Gun (includes Time Correction)
 df <- create_sprint_trace(MSS = 8, MAC = 6, time = seq(0, 6, 0.1))
+
+# Add some noise
+df$velocity <- df$velocity + rnorm(n = nrow(df), 0, 10^-2)
+
 m1 <- model_radar_gun(time = df$time, velocity = df$velocity)
 m1
 plot(m1)

--- a/man/model_functions.Rd
+++ b/man/model_functions.Rd
@@ -243,7 +243,10 @@ Family of functions that serve a purpose of estimating short sprint parameters
 
 # Model In-Situ (Embedded profiling)
 data("LPS_session")
-m1 <- model_in_situ(LPS_session$velocity, LPS_session$acceleration)
+m1 <- model_in_situ(
+  velocity = LPS_session$velocity,
+  acceleration = LPS_session$acceleration,
+  velocity_threshold = 4)
 m1
 plot(m1)
 


### PR DESCRIPTION
* Fixed the error in `model_radar_gun()` example that happened on `r-release-macos-arm64` and `r-oldrel-macos-arm64` due to the perfect model fit causing "singular gradient matrix at initial parameter estimates". This is sorted by adding simple noise to the simulated data
* Modified `model_in_situ()` function to now use `minpack.lm::nlsLM()` instead of `stats::lm()` function, which now estimates `MSS` and `MAC` parameters, and it is thus easier to read the code, and estimate the confidence intervals
* Updated the DESCRIPTION file with better package description