### PR TITLE
* For `model_in_situ()` function, the filtering parameters (`velocity…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # shorts (development version)
 
+* For `model_in_situ()` function, the filtering parameters (`velocity_threshold`, `velocity_step`, and `n_observations`) are returned in the `corrections` element of the returned object. These are also returned in the `CV` element of the returned object for every cross-validation fold
+* `velocity_threshold` parameter in the `model_in_situ()` function is now by default `NULL`, in which case the velocity of the observation with the fastest acceleration is taken as the cutoff value
+
 # shorts 3.1.0
 
 * Fixed the error in `model_radar_gun()` and `model_laser_gun()` examples that happened on `r-release-macos-arm64` and `r-oldrel-macos-arm64` due to the perfect model fit causing "singular gradient matrix at initial parameter estimates". This is sorted by adding simple noise to the simulated data

--- a/man/model_functions.Rd
+++ b/man/model_functions.Rd
@@ -25,7 +25,7 @@ model_in_situ(
   velocity,
   acceleration,
   weights = 1,
-  velocity_threshold = 3,
+  velocity_threshold = NULL,
   velocity_step = 0.2,
   n_observations = 2,
   CV = NULL,
@@ -154,7 +154,8 @@ model_timing_gates_TC_DC(
 \arguments{
 \item{weights}{Numeric vector. Default is 1}
 
-\item{velocity_threshold}{Default is 3 m/s}
+\item{velocity_threshold}{Velocity cutoff. If \code{NULL} (default), velocity of the observation with
+the fastest acceleration is taken as the cutoff value}
 
 \item{velocity_step}{Velocity increment size for finding max acceleration. Default is 0.2 m/s}
 
@@ -246,6 +247,7 @@ data("LPS_session")
 m1 <- model_in_situ(
   velocity = LPS_session$velocity,
   acceleration = LPS_session$acceleration,
+  # Use specific cutoff value
   velocity_threshold = 4)
 m1
 plot(m1)


### PR DESCRIPTION
…_threshold`, `velocity_step`, and `n_observations`) are returned in the `corrections` element of the returned object. These are also returned in the `CV` element of the returned object for every cross-validation fold

* `velocity_threshold` parameter in the `model_in_situ()` function is now by default `NULL`, in which case the velocity of the observation with the fastest acceleration is taken as the cutoff value